### PR TITLE
Put gleam-experiments/snag under the right heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Libraries for working with Erlang and OTP.
 
 Libraries for working with errors and computations that can fail.
 
-## File IO
-
 - [gleam-experiments/snag](https://github.com/gleam-experiments/snag) - A boilerplate-free ad-hoc error type.
+
+## File IO
 
 ## Generators
 


### PR DESCRIPTION
This appears under File IO, that seems to be the wrong header