### PR TITLE
Remove michallepicki/gleam-realworld-example-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Web applications written in Gleam.
 
 - [gleam-lang/example-echo-server](https://github.com/gleam-lang/example-url-shortener) - An example Gleam web application.
 - [greggreg/gleam_todo](https://gitlab.com/greggreg/gleam_todo) - A serverside only implementation of Todo MVC written in Gleam!
-- [michallepicki/gleam-realworld-example-app](https://github.com/michallepicki/gleam-realworld-example-app) - A RealWorld example app written in Gleam
 - [QuinnWilton/gleam-chip8](https://github.com/QuinnWilton/gleam-chip8) - A CHIP-8 emulator built with Gleam and Phoenix LiveView, playable [here](http://chip8.quinnwilton.com)
 - [toranb/elixir-gleam-match](https://github.com/toranb/elixir-gleam-match) - A game built with Gleam and Phoenix LiveView.
 


### PR DESCRIPTION
While it may have been useful in the past as an example JSON API web application template,
I haven't worked on it to keep it up to date with gleam language, stdlib and build system changes