### PR TITLE
Add emel library to the machine learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Libraries for serving traffic over HTTP.
 ## Machine learning
 
 - [mrdimosthenis/gleam_synapses](https://github.com/mrdimosthenis/gleam_synapses) - A lightweight library for neural networks.
+- [mrdimosthenis/emel](https://github.com/mrdimosthenis/emel) - A simple and functional machine learning library for the Erlang ecosystem
 
 ## Mimetypes
 


### PR DESCRIPTION
A simple and functional machine learning library, implemented in Gleam for the Erlang ecosystem.
https://github.com/mrdimosthenis/emel

I thought I would be able to translate the library [sooner](https://github.com/gleam-lang/awesome-gleam/pull/25#issuecomment-803313537). But I was wrong :slightly_smiling_face: 