### PR TITLE
Add `gleam-nibble` to the list of parser projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Libraries for parsing different kinds of data.
 - [delucks/pathlib](https://github.com/delucks/pathlib) - Manipulate Unix-style filesystem paths.
 - [sporto/gleam_codec](https://github.com/sporto/gleam_codec) - Build codecs (encode and decode) to transform data structures between Gleam and Elixir.
 - [pd-andy/gleam-string-parser](https://github.com/pd-andy/gleam-string-parser) - A simple parser combinator package written in Gleam.
+- [hayleigh-dot-dev/gleam-nibble](https://github.com/hayleigh-dot-dev/gleam-nibble) - A string parsing library heavily inspired by [elm/parser](https://github.com/elm/parser).
 - [sporto/gleam_qs](https://github.com/sporto/gleam_qs) - Parse and work with query strings.
 
 ## Protocols

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ Libraries for parsing different kinds of data.
 
 - [delucks/pathlib](https://github.com/delucks/pathlib) - Manipulate Unix-style filesystem paths.
 - [sporto/gleam_codec](https://github.com/sporto/gleam_codec) - Build codecs (encode and decode) to transform data structures between Gleam and Elixir.
-- [pd-andy/gleam-string-parser](https://github.com/pd-andy/gleam-string-parser) - A simple parser combinator package written in Gleam.
 - [hayleigh-dot-dev/gleam-nibble](https://github.com/hayleigh-dot-dev/gleam-nibble) - A string parsing library heavily inspired by [elm/parser](https://github.com/elm/parser).
 - [sporto/gleam_qs](https://github.com/sporto/gleam_qs) - Parse and work with query strings.
 


### PR DESCRIPTION
I recently picked up Gleam for the Advent of Code, so I looked up `pd-andy/gleam-string-parser` which redirects to `hayleigh-dot-dev/gleam-string-parser` but I couldn't `gleam add` it.
Looking around on the repo, I found `hayleigh-dot-dev/gleam-nibble` which was exactly what I was looking for, it's a great library that deserves to be on this awesome list.