### PR TITLE
Update Sublime Text package

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Web applications written in Gleam.
 - [gleam-lang/gleam.vim](https://github.com/gleam-lang/gleam.vim) - Gleam support for Vim/Neovim.
 - [gleam-lang/gleam-mode](https://github.com/gleam-lang/gleam-mode) - An emacs major mode for the Gleam programming language.
 - [gleam-lang/vscode-gleam](https://github.com/gleam-lang/vscode-gleam) - Gleam support for VS Code.
-- [molnarmark/sublime-gleam](https://github.com/molnarmark/sublime-gleam) - Gleam Syntax Definitions & Formatting for Sublime Text 3.
+- [digitalcora/sublime-text-gleam](https://github.com/digitalcora/sublime-text-gleam) - Gleam support for Sublime Text.
 - [sbdchd/neoformat](https://github.com/sbdchd/neoformat) - A Vim/Neovim plugin for formatting code with support for `gleam format`.
 - [itsgreggreg/language-gleam](https://github.com/itsgreggreg/language-gleam) - Gleam language support in Atom.
 - [DannyLettuce/gleam_gedit](https://github.com/DannyLettuce/gleam_gedit) - Gleam syntax support for Gedit (and other GtkSourceView editors).


### PR DESCRIPTION
The current linked package hasn't been updated since 2020, and appears to have never made it into Package Control (the main community repository of packages which are easily installable in-editor). I recently created this new package to better support recent syntax additions like `use`, and it has been [accepted into Package Control](https://packagecontrol.io/packages/Gleam), so it will be what comes up when anyone using Sublime Text searches for a "Gleam" package to install!