### PR TITLE
Add `simplifile` library to File IO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Libraries for working with errors and computations that can fail.
 ## File IO
 
 - [gleam-lang/erlang](https://github.com/gleam-lang/erlang) - Gleam's Erlang library contains a module for working with files and directories.
+- [bcpeinhardt/simplifile](https://github.com/bcpeinhardt/simplifile) - Simple file operations for Gleam that work on all targets (Erlang/Node/Deno)
 
 ## Generators
 


### PR DESCRIPTION
`simplifile` is a library that makes it easy to read and write from/to files, and works independently of whether the target is Erlang or Javascript