### PR TITLE
Add Conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Libraries for working with errors and computations that can fail.
 ## HTTP
 
 - [gleam-lang/http](https://github.com/gleam-lang/http) - Types and functions for HTTP clients and servers!
+- [MystPi/conversation](https://github.com/MystPi/conversation) - Bindings for the web standard JavaScript Request and Response APIs
 
 ## HTTP clients
 


### PR DESCRIPTION
Adds https://github.com/MystPi/conversation to the **HTTP** section.

I meant to write a better commit message, but I accidentally pressed enter before I could. 🫣