### PR TITLE
fixed link to `gleam-lang/example-todomvc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Compilers for Gleam and compilers written in Gleam.
 
 Web applications written in Gleam.
 
-- [gleam-lang/example-todomvc](https://github.com/gleam-lang/example-url-shortener) - A serverside only implementation of Todo MVC written in Gleam!
+- [gleam-lang/example-todomvc](https://github.com/gleam-lang/example-todomvc) - A serverside only implementation of Todo MVC written in Gleam!
 - [gleam-lang/example-echo-server](https://github.com/gleam-lang/example-echo-server) - An example Gleam web application.
 - [gleam-lang/packages](https://github.com/gleam-lang/packages) - The Gleam package index website.
 - [aosasona/jsorm](https://github.com/aosasona/jsorm) - A minimal JSON explorer in Gleam + HTMX.

--- a/src/awesome.gleam
+++ b/src/awesome.gleam
@@ -92,7 +92,7 @@ Compilers for Gleam and compilers written in Gleam.
 
 Web applications written in Gleam.
 
-- [gleam-lang/example-todomvc](https://github.com/gleam-lang/example-url-shortener) - A serverside only implementation of Todo MVC written in Gleam!
+- [gleam-lang/example-todomvc](https://github.com/gleam-lang/example-todomvc) - A serverside only implementation of Todo MVC written in Gleam!
 - [gleam-lang/example-echo-server](https://github.com/gleam-lang/example-echo-server) - An example Gleam web application.
 - [gleam-lang/packages](https://github.com/gleam-lang/packages) - The Gleam package index website.
 - [aosasona/jsorm](https://github.com/aosasona/jsorm) - A minimal JSON explorer in Gleam + HTMX.


### PR DESCRIPTION
The URL seems to be incorrect, so I fixed it.