### PR TITLE
Fix repo_url typo in sparkle.toml

### DIFF
--- a/packages/sparkle.toml
+++ b/packages/sparkle.toml
@@ -1,5 +1,5 @@
 name = "sparkle"
 description = "lib"
 docs_url = "https://hexdocs.pm/sparkle/"
-repo_url = "https://github.com/tomaszbawor/https://github.com/tomaszbawor/sparkle"
+repo_url = "https://github.com/tomaszbawor/sparkle"
 category = ""


### PR DESCRIPTION
It appears it got pasted twice and then partially overwritten.