### PR TITLE
Fix repo_url for libsql

### DIFF
--- a/packages/libsql.toml
+++ b/packages/libsql.toml
@@ -1,5 +1,5 @@
 name = "libsql"
 description = "An unofficial Gleam port of turso's libSQL library"
 docs_url = "https://hexdocs.pm/libsql/"
-repo_url = "https://github.com/brunoti/libsql"
+repo_url = "https://github.com/brunoti/gleam_libsql"
 category = ""


### PR DESCRIPTION
The current repo_url leads to a 404 page. It appears that the repo now lives at https://github.com/brunoti/gleam_libsql