### PR TITLE
Add 'matcha' under 'tools'

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,9 @@ Web applications written in Gleam.
 
 ## Tools
 
-- [tynanbe/rad](https://github.com/tynanbe/rad) - A flexible task runner companion for the Gleam build manager.
 - [inoas/glychee](https://github.com/inoas/glychee) - A simple Gleam benchmark runner which wraps Benchee for the heavy lifting.
+- [michaeljones/matcha](https://github.com/michaeljones/matcha) - A template system for Gleam
+- [tynanbe/rad](https://github.com/tynanbe/rad) - A flexible task runner companion for the Gleam build manager.
 
 ## Editor support
 

--- a/src/awesome.gleam
+++ b/src/awesome.gleam
@@ -101,8 +101,9 @@ Web applications written in Gleam.
 
 ## Tools
 
-- [tynanbe/rad](https://github.com/tynanbe/rad) - A flexible task runner companion for the Gleam build manager.
 - [inoas/glychee](https://github.com/inoas/glychee) - A simple Gleam benchmark runner which wraps Benchee for the heavy lifting.
+- [michaeljones/matcha](https://github.com/michaeljones/matcha) - A template system for Gleam
+- [tynanbe/rad](https://github.com/tynanbe/rad) - A flexible task runner companion for the Gleam build manager.
 
 ## Editor support
 


### PR DESCRIPTION
~~Matcha is gleam related but isn't a hex package and doesn't have a documentation page so I've taken the experimental step of allowing the 'docs_url' to be optional in the package tomls.~~

~~I've completely happy for this to be rejected if you want to keep things to just hex packages.~~

Edit: Added matcha under the tools section and sorted it alphabetically.