### PR TITLE
Rename `gleam_dotenv` to `dotenv_gleam`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Looking for something to build? Check out [the suggestions list][suggestions].
 ### Configuration
 
 - [dot_env](https://github.com/aosasona/dotenv) - [📚](https://hexdocs.pm/dot_env/) - Load environment variables from files
+- [dotenv_gleam](https://github.com/Grubba27/dotenv_gleam) - [📚](https://hexdocs.pm/dotenv_gleam/) - dotenv for Gleam
 - [envoy](https://github.com/lpil/envoy) - [📚](https://hexdocs.pm/envoy/) - A zero dependency cross platform Gleam package for reading environment variables
-- [gleam_dotenv](https://github.com/Grubba27/gleam_dotenv) - [📚](https://hexdocs.pm/gleam_dotenv/) - dotenv for Gleam
 - [glenv](https://github.com/custompro98/glenv) - [📚](https://hexdocs.pm/glenv/) - A library for type-safe environment variable access.
 - [glenvy](https://github.com/maxdeviant/glenvy) - [📚](https://hexdocs.pm/glenvy/) - A pleasant way to interact with your environment.
 

--- a/packages/dotenv_gleam.toml
+++ b/packages/dotenv_gleam.toml
@@ -1,4 +1,4 @@
 name = "dotenv_gleam"
 description = "dotenv for Gleam"
 repo_url = "https://github.com/Grubba27/dotenv_gleam"
-category = ""
+category = "Configuration"

--- a/packages/gleam_dotenv.toml
+++ b/packages/gleam_dotenv.toml
@@ -1,4 +1,4 @@
 name = "gleam_dotenv"
 description = "dotenv for Gleam"
 repo_url = "https://github.com/Grubba27/gleam_dotenv"
-category = "Configuration"
+category = ""


### PR DESCRIPTION
`gleam_dotenv` renamed to `dotenv_gleam`

https://github.com/Grubba27/dotenv_gleam/commit/38f72322d816ff9c4a723f5e3464157a3d74e050