### PR TITLE
Add gftp

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Looking for something to build? Check out [the suggestions list][suggestions].
 
 ### Networking
 
+- [gftp](https://github.com/veeso/gftp) - [📚](https://hexdocs.pm/gftp/) - A Gleam FTP/FTPS client library with full RFC support for both passive and active mode
 - [glisten](https://github.com/rawhat/glisten) - [📚](https://hexdocs.pm/glisten/) - a shiny Gleam TCP/SSL server
 - [mug](https://github.com/lpil/mug) - [📚](https://hexdocs.pm/mug/) - A TCP client for Gleam!
 - [nessie](https://github.com/ckreiling/nessie) - [📚](https://hexdocs.pm/nessie/) - Gleam bindings for Erlang's built-in DNS resolution modules.

--- a/packages/gftp.toml
+++ b/packages/gftp.toml
@@ -1,0 +1,4 @@
+name = "gftp"
+description = "A Gleam FTP/FTPS client library with full RFC support for both passive and active mode"
+repo_url = "https://github.com/veeso/gftp"
+category = "Networking"


### PR DESCRIPTION
I've added my FTP client library, [gftp](https://github.com/veeso/gftp), under the `Networking` section.