### PR TITLE
Add a2ml_gleam and k9_gleam packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Looking for something to build? Check out [the suggestions list][suggestions].
 - [envoy](https://github.com/lpil/envoy) - [📚](https://hexdocs.pm/envoy/) - A zero dependency cross platform Gleam package for reading environment variables
 - [glenv](https://github.com/custompro98/glenv) - [📚](https://hexdocs.pm/glenv/) - A library for type-safe environment variable access.
 - [glenvy](https://github.com/maxdeviant/glenvy) - [📚](https://hexdocs.pm/glenvy/) - A pleasant way to interact with your environment.
+- [k9_gleam](https://github.com/hyperpolymath/k9_gleam) - [📚](https://hexdocs.pm/k9_gleam/) - Parser and renderer for K9 (Self-Validating Components), configuration with trust levels and Nickel contracts
 
 ### Cryptography
 
@@ -180,6 +181,7 @@ Looking for something to build? Check out [the suggestions list][suggestions].
 
 ### Formats
 
+- [a2ml_gleam](https://github.com/hyperpolymath/a2ml_gleam) - [📚](https://hexdocs.pm/a2ml_gleam/) - Parser and renderer for A2ML (Attested Markup Language), an AI agent identity and attestation format
 - [commonmark](https://github.com/mscharley/gleam-commonmark) - [📚](https://hexdocs.pm/commonmark/) - CommonMark implementation for Gleam, for the BEAM or JS
 - [cymbal](https://github.com/lpil/cymbal) - [📚](https://hexdocs.pm/cymbal/) - Build YAML in Gleam!
 - [gsv](https://github.com/bcpeinhardt/gsv) - [📚](https://hexdocs.pm/gsv/) - A simple csv parser and generator written in gleam 

--- a/packages/a2ml_gleam.toml
+++ b/packages/a2ml_gleam.toml
@@ -1,0 +1,4 @@
+name = "a2ml_gleam"
+description = "Parser and renderer for A2ML (Attested Markup Language), an AI agent identity and attestation format"
+repo_url = "https://github.com/hyperpolymath/a2ml_gleam"
+category = "Formats"

--- a/packages/k9_gleam.toml
+++ b/packages/k9_gleam.toml
@@ -1,0 +1,4 @@
+name = "k9_gleam"
+description = "Parser and renderer for K9 (Self-Validating Components), configuration with trust levels and Nickel contracts"
+repo_url = "https://github.com/hyperpolymath/k9_gleam"
+category = "Configuration"


### PR DESCRIPTION
## Summary

- Adds `a2ml_gleam` (category: Formats) — parser and renderer for A2ML (Attested Markup Language), an AI agent identity and attestation format
- Adds `k9_gleam` (category: Configuration) — parser and renderer for K9 (Self-Validating Components), configuration with trust levels and Nickel contracts

## About A2ML and K9

**A2ML** (Attested Markup Language) is a lightweight markup format for AI agent identity and attestation. It provides a standardised way for AI systems to declare capabilities, provenance, and trust properties. An IANA media type registration is in progress (`application/a2ml`).

**K9** (Self-Validating Components) is a configuration format with built-in trust levels and Nickel contract integration. K9 files declare their own validation rules inline, enabling configuration that is both human-readable and formally verifiable.

Both formats have implementations across multiple language ecosystems (Rust, Elixir, Gleam). Both packages are published on Hex.