### PR TITLE
Add topics — topic-based pub/sub for Gleam

### DIFF
--- a/packages/topics.toml
+++ b/packages/topics.toml
@@ -1,0 +1,4 @@
+name = "topics"
+description = "Topic-based publish/subscribe for Gleam with automatic dead subscriber cleanup"
+repo_url = "https://github.com/manelsen/pubsub"
+category = "Erlang and OTP"


### PR DESCRIPTION
## topics

Topic-based publish/subscribe for Gleam with automatic dead subscriber cleanup.

- Generic message type: `PubSub(msg)` works with any Gleam type
- Dead subscriber auto-pruning on subscribe, broadcast, and count
- Ghost topic cleanup: `list_topics` excludes empty topics
- Idempotent subscribe: duplicate subscriptions are no-ops
- Supervisor-ready via `start_linked()`
- 13 tests, CI, full docs

**Links:**
- hex.pm: https://hex.pm/packages/topics
- docs: https://hexdocs.pm/topics/
- repo: https://github.com/manelsen/pubsub

Category: **Erlang and OTP** (actor-based registry pattern, similar to `chip`)