### PR TITLE
Add circuit_breaker package

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Looking for something to build? Check out [the suggestions list][suggestions].
 - [bath](https://github.com/Pevensie/bath) - [📚](https://hexdocs.pm/bath/) - A generic resource pool
 - [carpenter](https://github.com/grottohub/carpenter) - [📚](https://hexdocs.pm/carpenter/) - Bindings for Erlang's ETS tables. Forked and updated from gts.
 - [chip](https://github.com/chouzar/chip) - [📚](https://hexdocs.pm/chip/) - A Gleam registry library
+- [circuit_breaker](https://github.com/manelsen/circuitbreaker) - [📚](https://hexdocs.pm/circuit_breaker/) - Circuit breaker for Gleam — closed, open, half-open states with OTP actor support
 - [gen_core_erlang](https://codeberg.org/kero/gleam_codegen) - [📚](https://hexdocs.pm/gen_core_erlang/) - Generate Core Erlang from Gleam (wraps the Erlang cerl compiler module)
 - [gleam_erlang](https://github.com/gleam-lang/erlang) - [📚](https://hexdocs.pm/gleam_erlang/) - A Gleam library for working with Erlang
 - [gleam_otp](https://github.com/gleam-lang/otp) - [📚](https://hexdocs.pm/gleam_otp/) - Fault tolerant multicore Gleam programs with OTP

--- a/packages/circuit_breaker.toml
+++ b/packages/circuit_breaker.toml
@@ -1,0 +1,4 @@
+name = "circuit_breaker"
+description = "Circuit breaker for Gleam — closed, open, half-open states with OTP actor support"
+repo_url = "https://github.com/manelsen/circuitbreaker"
+category = "Erlang and OTP"


### PR DESCRIPTION
## Summary

- Adds `circuit_breaker` (category: Erlang and OTP) — circuit breaker for Gleam with closed, open, half-open state machine and OTP actor support

## Package

- **Hex:** https://hex.pm/packages/circuit_breaker
- **Docs:** https://hexdocs.pm/circuit_breaker/
- **Repo:** https://github.com/manelsen/circuitbreaker
- **License:** Apache-2.0

The package provides a pure state machine for circuit breaker logic, an OTP actor for thread-safe multi-key management, and a global registry via persistent_term. Published on Hex, v2.0.0.