### PR TITLE
Adding http_server_mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Looking for something to build? Check out [the suggestions list][suggestions].
 - [testbldr](https://github.com/bcpeinhardt/testbldr) - [📚](https://hexdocs.pm/testbldr/) - A library for programatically building and running test cases
 - [testcontainers_gleam](https://github.com/darky/testcontainers-gleam) - [📚](https://hexdocs.pm/testcontainers_gleam/) - Gleam TestContainers wrapper around Elixir TestContainers
 - [unitest](https://github.com/jtdowney/unitest) - [📚](https://hexdocs.pm/unitest/) - A test runner with random ordering, tagging, and CLI filtering
+- [http_server_mock](https://github.com/atomfinger/http_server_mock) - [📚](https://hexdocs.pm/http_server_mock/) - A mock server for integration testing
 
 ### Text
 


### PR DESCRIPTION
Adding http_server_mock

- GH: https://github.com/atomfinger/http_server_mock
- Docs: https://hexdocs.pm/http_server_mock/index.html

A simple mock server like [WireMock](https://wiremock.org/) or [MockServer](https://www.mock-server.com/), but written in Gleam, which supports both Erlang and JS targets.

Right now, it contains standard stubbing, but I hope to build it out to support automatic stubbing and request verification based on OpenAPI, as well as contract testing, such as Spring Cloud Contract. 